### PR TITLE
Fix editor and console colors

### DIFF
--- a/OneNord.xccolortheme
+++ b/OneNord.xccolortheme
@@ -23,11 +23,11 @@
 	<key>DVTConsoleExectuableOutputTextFont</key>
 	<string>SFMono-Regular - 14.0</string>
 	<key>DVTConsoleTextBackgroundColor</key>
-	<string>0.180392 0.203922 0.25098 1</string>
+	<string>0.135712 0.152563 0.191841 1</string>
 	<key>DVTConsoleTextInsertionPointColor</key>
-	<string>0.368627 0.505882 0.67451 1</string>
+	<string>0.812143 0.8386 0.892267 1</string>
 	<key>DVTConsoleTextSelectionColor</key>
-	<string>0.262745 0.298039 0.368627 1</string>
+	<string>0.202523 0.230471 0.29601 0.8</string>
 	<key>DVTFontAndColorVersion</key>
 	<integer>1</integer>
 	<key>DVTFontSizeModifier</key>
@@ -85,17 +85,17 @@
 	<key>DVTScrollbarMarkerWarningColor</key>
 	<string>0.937255 0.717647 0.34902 1</string>
 	<key>DVTSourceTextBackground</key>
-	<string>0.180392 0.203922 0.25098 1</string>
+	<string>0.135712 0.152563 0.191841 1</string>
 	<key>DVTSourceTextBlockDimBackgroundColor</key>
 	<string>0.5 0.5 0.5 1</string>
 	<key>DVTSourceTextCurrentLineHighlightColor</key>
-	<string>0.207843 0.231373 0.286275 1</string>
+	<string>0.176213 0.196927 0.253004 1</string>
 	<key>DVTSourceTextInsertionPointColor</key>
-	<string>0.368627 0.505882 0.67451 1</string>
+	<string>0.812143 0.8386 0.892267 1</string>
 	<key>DVTSourceTextInvisiblesColor</key>
-	<string>0.392157 0.415686 0.462745 1</string>
+	<string>0.23306 0.265222 0.340646 0.7</string>
 	<key>DVTSourceTextSelectionColor</key>
-	<string>0.262745 0.298039 0.368627 1</string>
+	<string>0.202523 0.230471 0.29601 0.8</string>
 	<key>DVTSourceTextSyntaxColors</key>
 	<dict>
 		<key>xcode.syntax.attribute</key>


### PR DESCRIPTION
As title says.

<img width="530" alt="image" src="https://github.com/rmehri01/onenord-xcode/assets/10441177/dcb73211-b37e-4eb0-8776-bcfc0c31305a">

Source editor

<img width="547" alt="image" src="https://github.com/rmehri01/onenord-xcode/assets/10441177/e04dfc09-19a5-433f-9a9d-8551f6a2f2ae">

Console

<img width="319" alt="image" src="https://github.com/rmehri01/onenord-xcode/assets/10441177/b5450d99-2e43-4dfa-9bd9-5f0e922e6010">
